### PR TITLE
Updates and SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *swp
 *tfstate
 *tfstate.backup
+/releases

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,9 @@ default: build
 build: fmtcheck
 	go install
 
+release:
+	gox -osarch "darwin/amd64 linux/amd64" -ldflags '-extldflags "-static"' -output "releases/{{.OS}}_{{.Arch}}/terraform-provider-mongodb"
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -1,7 +1,7 @@
 package mongodb
 
 import (
-	"gopkg.in/mgo.v2"
+	"github.com/globalsign/mgo"
 )
 
 type Config struct {

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -1,6 +1,10 @@
 package mongodb
 
 import (
+	"crypto/tls"
+	"net"
+	"net/url"
+
 	"github.com/globalsign/mgo"
 )
 
@@ -9,10 +13,27 @@ type Config struct {
 }
 
 func (c *Config) loadAndValidate() (*mgo.Session, error) {
-	session, err := mgo.Dial(c.URL)
+	mURI, err := url.Parse(c.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	return session, nil
+	qs := mURI.Query()
+	ssl := qs.Get("ssl") == "true"
+	qs.Del("ssl") // won't parse otherwise
+	mURI.RawQuery = qs.Encode()
+
+	dialInfo, err := mgo.ParseURL(mURI.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if ssl {
+		dialInfo.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+			tlsConfig := &tls.Config{}
+			return tls.Dial("tcp", addr.String(), tlsConfig)
+		}
+	}
+
+	return mgo.DialWithInfo(dialInfo)
 }

--- a/mongodb/provider_test.go
+++ b/mongodb/provider_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/globalsign/mgo"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"gopkg.in/mgo.v2"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/mongodb/resource_mongo_user.go
+++ b/mongodb/resource_mongo_user.go
@@ -3,8 +3,8 @@ package mongodb
 import (
 	"bytes"
 
+	"github.com/globalsign/mgo"
 	"github.com/hashicorp/terraform/helper/schema"
-	"gopkg.in/mgo.v2"
 )
 
 func resourceMongoDBUser() *schema.Resource {

--- a/mongodb/resource_mongo_user_test.go
+++ b/mongodb/resource_mongo_user_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/globalsign/mgo"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"gopkg.in/mgo.v2"
 )
 
 var testAccMongoDBUserConfig = fmt.Sprintf(`


### PR DESCRIPTION
- https://github.com/go-mgo/mgo is unmaintained so switch to https://github.com/globalsign/mgo
- add a `release` target to build static binaries for terraform
- add SSL support for Mongo connection strings (`?ssl=true`)